### PR TITLE
The function time.clock() has been removed

### DIFF
--- a/8_puzzle.py
+++ b/8_puzzle.py
@@ -195,9 +195,9 @@ board = [[1,2,3],[4,5,0],[6,7,8]]
 puzzle = Puzzle(board)
 #puzzle = puzzle.shuffle()
 s = Solver(puzzle)
-tic = time.clock()
+tic = time.perf_counter()
 p = s.solve()
-toc = time.clock()
+toc = time.perf_counter()
 
 steps = 0
 for node in p:


### PR DESCRIPTION
From https://docs.python.org/3/whatsnew/3.8.html

> The function time.clock() has been removed, after having been deprecated since Python 3.3: use time.perf_counter() or time.process_time() instead, depending on your requirements, to have well-defined behavior. (Contributed by Matthias Bussonnier in bpo-36895.)